### PR TITLE
Add codex command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # thrirebot
+
+## Comando `codex`
+
+Este bot conta com o comando `/codex` que permite enviar uma descrição ao Codex (OpenAI) para gerar novos códigos ou sugerir modificações. Para utilizar é necessário definir a variável de ambiente `OPENAI_API_KEY` com sua chave da API.

--- a/src/commands/codex.js
+++ b/src/commands/codex.js
@@ -1,0 +1,56 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { EmbedBuilder } from 'discord.js';
+import fetch from 'node-fetch';
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName('codex')
+        .setDescription('Envia uma solicitação ao Codex para gerar ou modificar códigos.')
+        .addStringOption(option =>
+            option
+                .setName('descricao')
+                .setDescription('Descrição do que deve ser gerado ou modificado.')
+                .setRequired(true)
+        ),
+    execute: async ({ interaction }) => {
+        const prompt = interaction.options.getString('descricao');
+        await interaction.deferReply();
+
+        try {
+            const res = await fetch('https://api.openai.com/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+                },
+                body: JSON.stringify({
+                    model: 'gpt-3.5-turbo',
+                    messages: [
+                        { role: 'user', content: prompt }
+                    ],
+                    temperature: 0.2
+                })
+            });
+
+            if (!res.ok) {
+                console.error(await res.text());
+                return await interaction.followUp('Erro ao comunicar com o Codex.');
+            }
+
+            const data = await res.json();
+            const text = data.choices?.[0]?.message?.content?.trim();
+            if (!text) {
+                return await interaction.followUp('O Codex não retornou nenhuma resposta.');
+            }
+
+            const embed = new EmbedBuilder()
+                .setTitle('Resposta do Codex')
+                .setDescription(text.slice(0, 4096));
+
+            await interaction.followUp({ embeds: [embed] });
+        } catch (err) {
+            console.error(err);
+            await interaction.followUp('Erro ao processar a requisição do Codex.');
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a `/codex` command that uses OpenAI to generate code snippets
- document usage of `codex` command

## Testing
- `node --check src/commands/codex.js`
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683fddc27920832e922d62a5212f135f